### PR TITLE
chore: replace GH_PAT with KUSIONSTACK_BOT_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,4 +75,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.KUSIONSTACK_BOT_TOKEN }}


### PR DESCRIPTION
Purpose:
* replace GH_PAT with KUSIONSTACK_BOT_TOKEN, because GH_PAT is a personal token.